### PR TITLE
feat: Standardize descriptor type input and improve example script

### DIFF
--- a/auto_chem_descriptors/main/main_auto_chem_descriptors.py
+++ b/auto_chem_descriptors/main/main_auto_chem_descriptors.py
@@ -67,7 +67,12 @@ def main_auto_chem_descriptors(n_jobs,
     is_force_field_true = False
 
     molecular_encoding = input_flow_controller['molecular_encoding']
-    descriptors_type = input_flow_controller['descriptors_type']
+    descriptors_type = input_flow_controller['descriptors_type'].upper()
+
+    # Legacy inputs still allow "SMILES" even though all RDKit-based flows
+    # now branch on "RDKIT".
+    if descriptors_type == "SMILES":
+        descriptors_type = "RDKIT"
     
     if len(calculator_controller) != 0:
        is_force_field_true = calculator_controller['is_force_field_true']

--- a/examples/patricia_project07/autochemdesc.py
+++ b/examples/patricia_project07/autochemdesc.py
@@ -1,3 +1,14 @@
+"""Entry point for running AutoChemDescriptors example locally."""
+
+from pathlib import Path
+import sys
+
+# Ensure the repository root (which contains the auto_chem_descriptors package)
+# is available when the script is executed directly from the examples folder.
+project_root = Path(__file__).resolve().parents[2]
+if project_root not in map(Path, sys.path):
+    sys.path.insert(0, str(project_root))
+
 #from auto_chem_descriptors.core.pipeline import main_auto_chem_descriptor
 from auto_chem_descriptors.main.main_auto_chem_descriptors import main_auto_chem_descriptors
 


### PR DESCRIPTION
Local example autochemdesc.py couldn’t import auto_chem_descriptors (ran outside repo path) and the "SMILES" descriptor option never hit the RDKit branches, so file handles were never created and the run crashed with UnboundLocalError. I fixed the entry-point to prepend the repo root to sys.path, then normalized descriptors_type values (uppercasing and mapping legacy "SMILES" to "RDKIT") so the RDKit flow executes correctly.